### PR TITLE
REV-9 Document AI agent integration via revopush/skills

### DIFF
--- a/intro/expo.md
+++ b/intro/expo.md
@@ -2,6 +2,33 @@
 
 This guide will help you to set up your Expo project and make first Revopush release.
 
+## Set up with an AI agent
+
+If you use an AI coding agent (Claude Code, Cursor, Codex, Gemini CLI, etc.), you can let it do the integration for you using our official agent skills from the [revopush/skills](https://github.com/revopush/skills) repository. The skills cover both Expo and plain React Native projects.
+
+Install the skills — for **Claude Code**:
+
+```shell
+/plugin marketplace add revopush/skills
+/plugin install revopush
+```
+
+For any other agent that supports the portable [`skills`](https://github.com/revopush/skills) CLI:
+
+```shell
+npx skills add https://github.com/revopush/skills
+```
+
+Then ask the agent to set everything up, for example:
+
+> Integrate Revopush OTA into my Expo project. Install the SDK and the Expo config plugin, configure the deployment keys in my app config, run prebuild, and wrap my root layout with `codePush()`.
+
+::: tip
+You still need a Revopush account, an application with deployment keys, and the [Revopush CLI](/cli/getting-started) to publish releases. The agent only handles the in-codebase integration described below.
+:::
+
+Prefer to do it by hand? Follow the manual steps below.
+
 ## Create an application
 
 1. Go to [Applications](https://app.revopush.org/applications) and add an application

--- a/intro/getting-started.md
+++ b/intro/getting-started.md
@@ -2,6 +2,41 @@
 
 This 5-minute guide will help you to set up your first Revopush integration
 
+## Set up with an AI agent
+
+If you use an AI coding agent (Claude Code, Cursor, Codex, Gemini CLI, etc.), the fastest way to integrate Revopush is to install our official agent skills from the [revopush/skills](https://github.com/revopush/skills) repository. The agent will then wire up the native iOS/Android (or Expo) changes, the JS `codePush()` wrapper, and the deployment keys for you — for both plain **React Native** and **Expo** projects.
+
+#### Install the skills
+
+For **Claude Code**, add the marketplace and install the plugin:
+
+```shell
+/plugin marketplace add revopush/skills
+/plugin install revopush
+```
+
+For any other agent that supports the portable [`skills`](https://github.com/revopush/skills) CLI:
+
+```shell
+npx skills add https://github.com/revopush/skills
+```
+
+#### Ask the agent to set up Revopush
+
+Once the skill is installed, just describe what you want in plain language and the agent will pick up the right skill automatically. For example:
+
+> Set up Revopush OTA updates in my React Native app. Add the iOS and Android native integration, wrap my root component with `codePush()`, and add a deployment key placeholder I can fill in.
+
+For an Expo project:
+
+> Integrate Revopush OTA into my Expo project. Install the SDK and the Expo config plugin, configure the deployment keys in my app config, run prebuild, and wrap my root layout with `codePush()`.
+
+::: tip
+You still need a Revopush account and an application with deployment keys (see below). The agent integrates the SDK in your codebase — you provide the keys from the dashboard and use the [Revopush CLI](/cli/getting-started) to publish releases.
+:::
+
+Prefer to do it by hand? Follow the manual steps below.
+
 ## Create an account
 
 First, you need to create an account at the following service: https://app.revopush.org/register


### PR DESCRIPTION
## Summary
Documents that Revopush OTA integration can be done via the AI agent skills we provide in [revopush/skills](https://github.com/revopush/skills).

Adds a **"Set up with an AI agent"** section to both integration guides:
- `intro/getting-started.md` (React Native)
- `intro/expo.md` (Expo)

Each section covers:
- Installing the skills — Claude Code (`/plugin marketplace add revopush/skills` + `/plugin install revopush`) and the portable CLI (`npx skills add https://github.com/revopush/skills`).
- Example prompts to ask the agent to set up Revopush OTA — one for React Native, one for Expo.
- A tip clarifying the agent handles in-codebase integration while the user still needs an account, deployment keys, and the CLI to publish releases.

## Linear
REV-9 — https://linear.app/revopush/issue/REV-9/document-ai-agent-integration-via-revopushskills

## Verification
`pnpm build` completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)