### PR TITLE
REV-13 Default version matrix to 2.5.x / 2.6.x across RN and Expo

### DIFF
--- a/intro/expo.md
+++ b/intro/expo.md
@@ -47,8 +47,6 @@ Prefer to do it by hand? Follow the manual steps below.
 
 Revopush SDK doesn't work with Expo Go because it requires native code changes.
 
-> Only legacy apps still on the original **Microsoft CodePush** client need to stay on the old client. Everyone else should use the Revopush **2.x** SDK by default.
-
 | Expo SDK     | Revopush SDK | Revopush Expo plugin |
 |--------------|--------------|----------------------|
 | 52 – 54      | 2.5.x        | 1.0.x                |

--- a/intro/expo.md
+++ b/intro/expo.md
@@ -47,10 +47,12 @@ Prefer to do it by hand? Follow the manual steps below.
 
 Revopush SDK doesn't work with Expo Go because it requires native code changes.
 
-| Expo SDK | Revopush SDK | Revopush Expo plugin |
-|----------|--------------|----------------------|
-| 52-54    | 1.5.0        | 1.0.1                |
-| 55       | 1.6.0        | 1.1.0                |
+> Only legacy apps still on the original **Microsoft CodePush** client need to stay on the old client. Everyone else should use the Revopush **2.x** SDK by default.
+
+| Expo SDK     | Revopush SDK | Revopush Expo plugin |
+|--------------|--------------|----------------------|
+| 52 – 54      | 2.5.x        | 1.0.x                |
+| 55 and above | 2.6.x        | 1.1.x                |
 
 #### Install Revopush SDK
 

--- a/intro/getting-started.md
+++ b/intro/getting-started.md
@@ -65,10 +65,15 @@ First, you need to decide what client SDK to use. We support two options:
 - For React Native **>=0.76**, or you need support for New Architecture, you should use Revopush client SDK.
 - For Expo SDK 52+ follow [Expo configuration instructions](/intro/expo)
 
-| React Native version(s)            | Supporting CodePush version(s)                                                                                                   |             
-|------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| <v0.76                             | Use old Microsoft [CodePush client](https://github.com/microsoft/react-native-code-push)                                         |
-| 0.76, 0.77, 0.78, 0.79, 0.80, 0.81 | Use [Revopush SDK](https://github.com/revopush/react-native-code-push) **v1.5.1** and above (Support both New and Old Architectures) |
+> Only legacy apps still on the original **Microsoft CodePush** client (React Native **< 0.76**, Old Architecture only) need to stay on the old client. Everyone else should use the Revopush **2.x** SDK by default.
+
+| Platform     | Version(s)             | Supporting Revopush SDK version(s)                                                                     |
+|--------------|------------------------|-------------------------------------------------------------------------------------------------------|
+| React Native | < 0.76 (Old Arch only) | Use the legacy Microsoft [CodePush client](https://github.com/microsoft/react-native-code-push)       |
+| React Native | 0.76 – 0.82            | [Revopush SDK](https://github.com/revopush/react-native-code-push) **2.5.x** (New & Old Architecture)  |
+| React Native | 0.83 and above         | [Revopush SDK](https://github.com/revopush/react-native-code-push) **2.6.x** (New & Old Architecture)  |
+| Expo SDK     | 52 – 54                | Revopush SDK **2.5.x** + Expo plugin **1.0.x** — see [Expo guide](/intro/expo)                         |
+| Expo SDK     | 55 and above           | Revopush SDK **2.6.x** + Expo plugin **1.1.x** — see [Expo guide](/intro/expo)                         |
 
 #### For this guide we will use Revopush SDK
 

--- a/revopush20/getting-started.md
+++ b/revopush20/getting-started.md
@@ -25,17 +25,22 @@ First, you need to create an account at the following service: https://app.revop
 
 - For React Native **>=0.76**, or you need support for New Architecture, you should use Revopush client SDK.
 
-| React Native version(s) | Supporting CodePush version(s)           |             
-|-------------------------|------------------------------------------|
-| 0.76 - 0.82             | @revopush/react-native-code-push@2.5.1   |
-| 0.83                    | @revopush/react-native-code-push@1.6.0   |
+> Only legacy apps still on the original **Microsoft CodePush** client (React Native **< 0.76**, Old Architecture only) need to stay on the old client. Everyone else should use the Revopush **2.x** SDK by default.
+
+| Platform     | Version(s)             | Supporting Revopush SDK version(s)                                                               |
+|--------------|------------------------|-------------------------------------------------------------------------------------------------|
+| React Native | < 0.76 (Old Arch only) | Use the legacy Microsoft [CodePush client](https://github.com/microsoft/react-native-code-push) |
+| React Native | 0.76 – 0.82            | `@revopush/react-native-code-push@2.5.x` (New & Old Architecture)                               |
+| React Native | 0.83 and above         | `@revopush/react-native-code-push@2.6.x` (New & Old Architecture)                               |
+| Expo SDK     | 52 – 54                | `@revopush/react-native-code-push@2.5.x` + Expo plugin `1.0.x` — see [Expo guide](/intro/expo)  |
+| Expo SDK     | 55 and above           | `@revopush/react-native-code-push@2.6.x` + Expo plugin `1.1.x` — see [Expo guide](/intro/expo)  |
 
 #### For this guide we will use Revopush SDK
 
 Install Revopush client:
 
 ```bash
-npm install --save @revopush/react-native-code-push@2.5.1
+npm install --save @revopush/react-native-code-push
 ```
 
 #### Setup iOS

--- a/sdk/getting-started.md
+++ b/sdk/getting-started.md
@@ -46,10 +46,15 @@ In order to ensure that your end users always have a functioning version of your
 We try our best to maintain backwards compatibility of our plugin with previous versions of React Native, but due to the nature of the platform, and the existence of breaking changes between releases, it is possible that you need to use a specific version of the CodePush plugin in order to support the exact version of React Native you are using. The following table outlines which CodePush plugin versions officially support the respective React Native versions:
 
 
-| React Native version(s) | Supporting CodePush version(s)                                                                                                     |             
-|-----------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| <v0.76                | Use old Microsoft [CodePush client](https://github.com/microsoft/react-native-code-push)                                           |
-| 0.76, 0.77, 0.78, 0.79, 0.80, 0.81    | Use [Revopush SDK](https://github.com/revopush/react-native-code-push) **v1.5.1** and above (Support both New and Old Architectures) |
+> Only legacy apps still on the original **Microsoft CodePush** client (React Native **< 0.76**, Old Architecture only) need to stay on the old client. Everyone else should use the Revopush **2.x** SDK by default.
+
+| Platform     | Version(s)             | Supporting Revopush SDK version(s)                                                                     |
+|--------------|------------------------|-------------------------------------------------------------------------------------------------------|
+| React Native | < 0.76 (Old Arch only) | Use the legacy Microsoft [CodePush client](https://github.com/microsoft/react-native-code-push)       |
+| React Native | 0.76 – 0.82            | [Revopush SDK](https://github.com/revopush/react-native-code-push) **2.5.x** (New & Old Architecture)  |
+| React Native | 0.83 and above         | [Revopush SDK](https://github.com/revopush/react-native-code-push) **2.6.x** (New & Old Architecture)  |
+| Expo SDK     | 52 – 54                | Revopush SDK **2.5.x** + Expo plugin **1.0.x** — see [Expo guide](/intro/expo)                         |
+| Expo SDK     | 55 and above           | Revopush SDK **2.6.x** + Expo plugin **1.1.x** — see [Expo guide](/intro/expo)                         |
 
 
 We work hard to respond to new RN releases, but they do occasionally break us. We will update this chart with each RN release, so that users can check to see what our "official" support is.


### PR DESCRIPTION
## Summary
Makes the Revopush **2.x** client the default everywhere and consolidates the SDK version matrix into a single table covering **all React Native and Expo SDK versions**.

Version rule applied: `1.5 → 2.5`, `1.6 → 2.6`.

| Platform | Version(s) | Revopush SDK |
|----------|------------|--------------|
| React Native | < 0.76 (Old Arch only) | Legacy Microsoft CodePush client |
| React Native | 0.76 – 0.82 | 2.5.x |
| React Native | 0.83 and above | 2.6.x |
| Expo SDK | 52 – 54 | 2.5.x (plugin 1.0.x) |
| Expo SDK | 55 and above | 2.6.x (plugin 1.1.x) |

Only legacy apps still on the original Microsoft CodePush client (RN < 0.76, Old Architecture only) stay on the old client; everyone else uses Revopush 2.x by default.

## Files
- `intro/getting-started.md`
- `sdk/getting-started.md`
- `revopush20/getting-started.md`
- `intro/expo.md`

Linear: [REV-13](https://linear.app/revopush/issue/REV-13/docs-default-version-matrix-to-25x-26x-across-rn-and-expo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)