### PR TITLE
REV-47: add product change logs

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -86,6 +86,7 @@ export default defineConfig({
                     {text: 'Rolling Back Updates', link: '/cli/rolling-back-updates'},
                     {text: 'Release History', link: '/cli/release-history'},
                     {text: 'Code Signing', link: '/cli/code-signing'},
+                    {text: 'Changelog', link: '/cli/changelog'},
                 ]
             },
             {
@@ -100,6 +101,7 @@ export default defineConfig({
                     {text: 'iOS API', link: '/sdk/api-ios'},
                     {text: 'Multi-Deployment Testing iOS', link: '/sdk/multi-deployment-testing-ios'},
                     {text: 'Multi-Deployment Testing Android', link: '/sdk/multi-deployment-testing-android'},
+                    {text: 'Changelog', link: '/sdk/changelog'},
                 ]
             },
             {

--- a/cli/changelog.md
+++ b/cli/changelog.md
@@ -1,0 +1,54 @@
+# CLI changelog
+
+## 0.0.13 — June 15, 2026
+
+- Added support for reading Android versions from Kotlin DSL (`build.gradle.kts`) projects.
+- Fixed IPA extraction for archives whose app payload contains extra files or nested paths.
+
+## 0.0.12 — May 18, 2026
+
+- Added native build targeting to releases. The CLI can read iOS `CFBundleVersion` and Android `versionCode`, and pass a build number when creating React Native, Expo, or native releases.
+- Added `--buildNumber` support to `deployment patch`, including the ability to reset a release to all builds.
+- Made build-number targeting optional and limited automatic detection to compatible Revopush SDK versions.
+- Fixed Hermes discovery in projects that only contain one native platform.
+
+## 0.0.11 — February 7, 2026
+
+- Improved monorepo support by resolving the installed React Native version from `react-native/package.json` instead of relying on a project-relative Hermes path.
+
+## 0.0.10 — February 2, 2026
+
+- Fixed iOS plist parsing when extracting release metadata.
+
+## 0.0.9 — January 30, 2026
+
+- Added Android App Bundle (`.aab`) support to `release-native`.
+
+## 0.0.8 — January 15, 2026
+
+- Added `release-expo` for building and publishing Expo updates.
+- Added `release-native` for publishing existing iOS IPA and Android APK artifacts, with automatic native-version detection.
+- Added React Native 0.83 support.
+- Added base Hermes bytecode metadata used by differential updates.
+- Added `--initialRelease` for creating an app's first release.
+- Added `--force` to `deployment rm` for non-interactive deletion.
+- Fixed the logout help text.
+
+## 0.0.7 — August 28, 2025
+
+- Fixed module imports in the release command after the Hermes and source-map changes.
+
+## 0.0.6 — August 28, 2025
+
+- Fixed release metrics handling.
+
+## 0.0.5 — August 28, 2025
+
+- Added automatic Hermes detection for React Native projects.
+- Added platform-specific Hermes compilation and source-map output handling for iOS and Android.
+- Standardized generated source maps as `CodePushSourceMap` and corrected Metro/Hermes source-map arguments.
+- Improved `node_modules` discovery, including projects where dependencies are not in the default location.
+
+## 0.0.4 — April 8, 2025
+
+- Added `--extraBundlerOption` to `release-react`, allowing additional arguments to be forwarded to the React Native bundler.

--- a/sdk/changelog.md
+++ b/sdk/changelog.md
@@ -1,0 +1,98 @@
+# React Native SDK changelog
+
+Revopush maintains two SDK release lines and an Expo config plugin:
+
+- **2.x** is the current SDK with differential update support.
+- **1.x** is the maintenance line for applications that have not migrated to 2.x.
+- **Expo config plugin** applies the required iOS and Android configuration during Expo prebuild.
+
+## SDK 2.x
+
+### 2.6.0 — June 22, 2026
+
+- Added React Native 0.83 compatibility on Android and iOS, including updated native-module and React host integration.
+- Fixed asset-hash calculation for native iOS releases.
+- Fixed Android compilation after the React Native 0.83 changes.
+
+### 2.5.1 — June 11, 2026
+
+- Fixed iOS asset-hash calculation when an OTA update is based on a native release.
+
+### 2.5.0 — May 25, 2026
+
+- Added differential OTA updates on both iOS and Android. Updates can reuse the native bundle and assets instead of downloading a complete package.
+- Added native-build metadata generation for bundled resources, asset hashes, and the application manifest.
+- Added native build-number reporting (`CFBundleVersion` on iOS and `versionCode` on Android), enabling releases to target a specific build.
+- Moved the Android differential-update runtime to Maven Central and updated it with 16 KB page-alignment support.
+- Moved Android PNG processing into Gradle and fixed PNG crunching for generated update assets.
+- Improved recovery when applying a differential bundle fails.
+
+### 2.0.0 — November 19, 2025
+
+- Introduced the 2.x SDK line and the first differential-update implementation for iOS and Android.
+- Added generation and native handling of bundle, asset, and resource metadata required by differential updates.
+- Added React Native 0.81 compatibility.
+- Switched SDK network requests and native integration from the legacy CodePush service to Revopush.
+
+> Versions 2.1.0 through 2.4.0 only appeared as release candidates during 2.5.0 development and did not contain separate stable release changes.
+
+## SDK 1.x
+
+### 1.6.0 — May 18, 2026
+
+- Added React Native 0.83 support to the 1.x maintenance line.
+
+### 1.5.1 — February 20, 2026
+
+- Added the `ignoreFailedUpdates` sync option, allowing an update to be installed even when it was previously marked as failed.
+- Fixed React host delegate integration for React Native versions earlier than 0.81.
+
+### 1.5.0 — November 2, 2025
+
+- Added Android support for React Native 0.81.
+- Updated Android ProGuard rules for release builds.
+
+### 1.4.0 — September 22, 2025
+
+- Fixed a native-module name collision in applications containing another CodePush-compatible module.
+
+### 1.3.0 — August 21, 2025
+
+- Added Android support for loading Expo-generated bundles.
+
+### 1.2.0 — June 21, 2025
+
+- Replaced React Native's internal `ChoreographerCompat` dependency with the Android platform `Choreographer`, improving compatibility with newer React Native versions.
+
+### 1.1.0 — April 13, 2025
+
+- Fixed Android ProGuard rules so the SDK works correctly in minified release builds.
+
+### 1.0.0 — March 3, 2025
+
+- Published the first Revopush SDK release under `@revopush/react-native-code-push`.
+- Made the Revopush API the default update server and updated the bundled commands and documentation for the Revopush CLI.
+- Removed the unsupported Windows implementation from the Revopush package.
+
+## Expo config plugin
+
+The Expo plugin is published separately as `@revopush/expo-code-push-plugin`. It is required for Expo projects because the Revopush SDK needs native configuration and cannot run in Expo Go.
+
+### 1.1.0 — May 18, 2026
+
+- Added Expo SDK 55 support for projects using Revopush SDK 1.6.0 or later.
+- Added support for Expo's newer Kotlin `getDefaultReactHost` application template.
+- Added Objective-C AppDelegate support alongside the existing Swift integration.
+- Added the optional `CodePushPublicKey` setting on iOS and Android for signed OTA updates.
+- Updated locked dependencies and forced a patched `uuid` version to address security vulnerabilities.
+
+### 1.0.1 — August 21, 2025
+
+- Published the plugin under the final `@revopush/expo-code-push-plugin` package name.
+- Added installation, Expo config, prebuild, and compatibility documentation.
+
+### 1.0.0 — August 19, 2025
+
+- Introduced the Revopush Expo config plugin for Expo SDK 52 and newer.
+- Added automatic iOS and Android native configuration for deployment keys and custom Revopush server URLs.
+- Added the native project changes required to load the Revopush bundle after `expo prebuild`.


### PR DESCRIPTION
## Summary

Adds changelog pages for the Revopush CLI and React Native SDK, based on repository release history.

## Context

Provides a clear overview of user-facing changes across CLI, SDK 1.x, SDK 2.x, and the Expo config plugin.

## Changes

- Added /cli/changelog.
- Added /sdk/changelog.
- Documented CLI and SDK changes by version.
- Added Expo config plugin release history.
- Added changelog links to the documentation sidebar.

## How was this tested?

Ran the VitePress production build locally.
Ran the test suite.
Verified the generated /cli/changelog and /sdk/changelog pages.
