### PR TITLE
ci: rename job test → check for org-wide consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  check:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Renames the CI job `test` → `check` so the emitted status-check context is `check`, matching the rest of the revopush org (18 repos already use `check`). This lets a single ruleset definition requiring `check` apply uniformly instead of carving out `test` for this repo.

One-line change; the job's steps are untouched.

⚠️ **Coordinate with branch protection / the ruleset switch.** This changes the status context from `test` to `check`. If this repo currently *requires* the `test` context, this PR will not be mergeable on its own — it now emits `check`, so a required `test` will never report. Merge it together with switching the required check to `check` (an admin merge, or drop the `test` requirement first). If `test` isn't currently required, it merges normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)